### PR TITLE
Optimize webpack chunking and output files

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "prod": "NODE_ENV=production nginx",
     "dev:all": "concurrently \"cross-env npm run start:dev\" \"cross-env npm run dev\"",
     "prod:all": "concurrently \"cross-env npm run start:prod\" \"cross-env npm run prod\"",
-    "stop:prod": "nginx -s stop && kill -9 `lsof -i:5000 -t`"
+    "stop:prod": "nginx -s stop && kill -9 `lsof -i:5000 -t`",
+    "webpack:analyze": "webpack --json > stats.json"
   },
   "author": "",
   "license": "ISC",
@@ -26,6 +27,7 @@
     "css-loader": "^6.8.1",
     "html-webpack-plugin": "^5.5.3",
     "jest": "^29.6.2",
+    "mini-css-extract-plugin": "^2.7.6",
     "style-loader": "^3.3.3",
     "ts-loader": "^9.4.4",
     "typescript": "^5.1.6",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,12 +1,15 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 module.exports = {
   mode: process.env.NODE_ENV,
   entry: './client/src/App.tsx',
   output: {
-    filename: 'bundle.js',
+    filename: 'static/js/[name].[chunkhash:8].js',
+    chunkFilename: 'static/js/[name].[chunkhash:8].chunk.js',
     path: path.resolve(__dirname, 'dist'),
+    clean: true,
   },
   module: {
     rules: [
@@ -19,13 +22,32 @@ module.exports = {
         test: /\.css$/i,
         exclude: /node_modules/,
         use: [
-          'style-loader',
-          'css-loader',
+          MiniCssExtractPlugin.loader,
+          {
+            loader: "css-loader",
+            options: {
+              importLoaders: 1,
+              modules: true,
+            },
+          },
+          // 'style-loader',
+          // 'css-loader',
           // 'postcss-loader',
           // 'sass-loader'
         ]
       }
     ]
+  },
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        reactVendor: {
+          test: /[\\/]node_modules[\\/](react|react-dom|react-router-dom)[\\/]/,
+          name: 'vendor-react',
+          chunks: 'all',
+        },
+      },
+    },
   },
   resolve: {
     extensions: ['.js', '.jsx','.ts', '.tsx', '.css']
@@ -35,6 +57,10 @@ module.exports = {
       title: 'Development',
       template: 'client/index.html'
     }),
+    new MiniCssExtractPlugin({
+      filename: "static/css/[name].[chunkhash:8].css",
+      chunkFilename: "static/css/[name].[chunkhash:8].chunk.css"
+    })
   ],
   devServer: {
     host: 'localhost',
@@ -46,7 +72,7 @@ module.exports = {
     proxy: {
       '/api': {
         target: 'http://localhost:5000',
-        pathRewrite: {'^/api': ''},
+        // pathRewrite: {'^/api': ''},
       }
     }
   }


### PR DESCRIPTION
Created a `/static` folder for webpack outputs
Added chunking and hashing of chunk file names

Added a `webpack:analyze` script for analyzing how chunking is done.
Use the `stats.json` file here: https://chrisbateman.github.io/webpack-visualizer/


Resources:
Subdirectories for webpack output folder: https://zero2603.medium.com/how-to-deploy-reactjs-app-into-subdirectory-with-webpack-58d5ce32c655
CSS modules with webpack: https://blog.logrocket.com/how-to-configure-css-modules-webpack/
Webpack code splitting: https://www.codemzy.com/blog/react-bundle-size-webpack-code-splitting
Webpack code splitting by Create-React-App: https://create-react-app.dev/docs/code-splitting
